### PR TITLE
feat - minor changes for making production service run locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.idea/
+logdata/
 # backend/data

--- a/app.sh
+++ b/app.sh
@@ -1,39 +1,58 @@
-#! /bin/sh -
+#! /bin/bash
 
 NUM_ARGS="$#"
 RUN_COMMAND="$1"
 OCEL_MOUNT_PATH="$2"
 
-# https://stackoverflow.com/questions/7522712/how-can-i-check-if-a-command-exists-in-a-shell-script
-DOCKER_COMPOSE="docker-compose"
-if ! type "$DOCKER_COMPOSE" >> /dev/null; then
+if command -v docker compose &> /dev/null; then
     DOCKER_COMPOSE="docker compose"
+elif command -v docker-compose &> /dev/null; then
+    DOCKER_COMPOSE="docker-compose"
+else
+    echo "Error: Neither 'docker compose' nor 'docker-compose' found."
+    exit 1
 fi
 
 if [[ $NUM_ARGS -ne 1 && $NUM_ARGS -ne 2 ]]; then
     echo "Please provide an app command and optionally a path to a folder of event logs to mount, e.g.: >> ./app.sh --start ../my_ocels/"
     echo "For more information, e.g. all available commands, see the user manual."
-    exit -1
+    exit 1
 fi
 
 if [[ -n "$OCEL_MOUNT_PATH" ]]; then
+    if ! command -v realpath &> /dev/null; then
+        echo "Error: 'realpath' command not found. Please install it (e.g., sudo apt install coreutils)."
+        exit 1
+    fi
     OCEL_MOUNT_PATH=$(realpath "$OCEL_MOUNT_PATH")
     if [[ ! -d "$OCEL_MOUNT_PATH" ]]; then
         echo "$OCEL_MOUNT_PATH is not a valid directory or does not exist."
-        exit -1
+        exit 1
     fi
 fi
 
 case "$RUN_COMMAND" in
     ("--start")
+        if ! $DOCKER_COMPOSE build --no-cache _backend_base; then
+            echo "Error: Failed to build the backend base image."
+            exit 1
+        fi
         if [[ -n "$OCEL_MOUNT_PATH" ]]; then
-            $DOCKER_COMPOSE build --no-cache _backend_base && OCEL_MOUNT_PATH="$OCEL_MOUNT_PATH" $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.mount-ocels.yml -f docker-compose.prod.yml up --build --no-cache --detach
+            export OCEL_MOUNT_PATH="$OCEL_MOUNT_PATH" 
+            $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.mount-ocels.yml -f docker-compose.prod.yml config --services | grep -v _backend_base | xargs $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.mount-ocels.yml -f docker-compose.prod.yml build --no-cache
+            $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.mount-ocels.yml -f docker-compose.prod.yml up
         else
-            $DOCKER_COMPOSE build --no-cache _backend_base && $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.prod.yml up --build --no-cache --detach
+            $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.prod.yml config --services | grep -v _backend_base | xargs $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.prod.yml build --no-cache
+            $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.prod.yml up --detach
         fi
         ;;
-    ("--start-dev") 
-        $DOCKER_COMPOSE build _backend_base && $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.dev.yml up --build --detach
+    ("--start-dev")
+        if ! $DOCKER_COMPOSE build _backend_base; then
+                echo "Docker build failed. Exiting."
+                exit 1
+        fi
+        $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.dev.yml config --services | grep -v _backend_base | xargs $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.dev.yml build --no-cache
+        $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.dev.yml up --detach
         ;;
     ("--stop") 
         $DOCKER_COMPOSE stop
@@ -43,6 +62,7 @@ case "$RUN_COMMAND" in
         ;;
     (*) 
         echo "Please provide a valid app command, e.g. --start. For more information, e.g. all available commands, see the user manual."
+        exit 1
         ;;
 esac
 

--- a/backend/Dockerfile_backend
+++ b/backend/Dockerfile_backend
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.10-slim@sha256:e04bc5390a13e6e910980715f1156552fbd3deddf7668e1892575989f9504c70 AS builder
+FROM python:3.10-slim@sha256:e04bc5390a13e6e910980715f1156552fbd3deddf7668e1892575989f9504c70 AS builder
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential

--- a/backend/Dockerfile_celery
+++ b/backend/Dockerfile_celery
@@ -1,13 +1,14 @@
-ARG BUILD_ENV
+ARG BUILD_ENV=default
 
-FROM explori-backend-base-image as common_pre_build
+FROM explori-backend-base-image AS common_pre_build
 ONBUILD WORKDIR /explori/celery
 
-FROM common_pre_build as prod_build
+FROM common_pre_build AS prod_build
 ONBUILD COPY src/ src/
 ONBUILD COPY data/uploaded/demo_ocel.jsonocel data/uploaded/demo_ocel.jsonocel
 
-FROM common_pre_build as dev_build
+FROM common_pre_build AS dev_build
 
 FROM ${BUILD_ENV}_build
-CMD PYTHONUNBUFFERED=1 EXPLORI_REDIS_HOST=${REDIS_HOST} EXPLORI_REDIS_PORT=${REDIS_PORT} PYTHONPATH="src/" celery --app=worker.main.app worker --loglevel=INFO
+# CMD ["env", "PYTHONUNBUFFERED=1", "EXPLORI_REDIS_HOST=${REDIS_HOST}", "EXPLORI_REDIS_PORT=${REDIS_PORT}", "PYTHONPATH=src/", "celery", "--app=worker.main.app", "worker", "--loglevel=INFO"]
+CMD ["sh", "-c", "PYTHONUNBUFFERED=1 EXPLORI_REDIS_HOST=${REDIS_HOST} EXPLORI_REDIS_PORT=${REDIS_PORT} PYTHONPATH=src/ celery --app=worker.main.app worker --loglevel=INFO"]

--- a/backend/Dockerfile_fastapi
+++ b/backend/Dockerfile_fastapi
@@ -1,14 +1,15 @@
-ARG BUILD_ENV
+ARG BUILD_ENV=default
 
-FROM explori-backend-base-image as common_pre_build
+FROM explori-backend-base-image AS common_pre_build
 ONBUILD WORKDIR /explori/fastapi
 
-FROM common_pre_build as prod_build
+FROM common_pre_build AS prod_build
 ONBUILD COPY src/ src/
 ONBUILD COPY data/uploaded/demo_ocel.jsonocel data/uploaded/demo_ocel.jsonocel
 
-FROM common_pre_build as dev_build
+FROM common_pre_build AS dev_build
 ONBUILD ENV DEV=1
 
 FROM ${BUILD_ENV}_build
-CMD DEV=${DEV} PYTHONUNBUFFERED=1 EXPLORI_REDIS_HOST=${REDIS_HOST} EXPLORI_REDIS_PORT=${REDIS_PORT} PYTHONPATH="src/" uvicorn server.main:app --host 0.0.0.0 --port 8080
+# CMD ["env", "DEV=${DEV}", "PYTHONUNBUFFERED=1", "EXPLORI_REDIS_HOST=${REDIS_HOST}", "EXPLORI_REDIS_PORT=${REDIS_PORT}", "PYTHONPATH=src/", "uvicorn", "server.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["sh", "-c", "DEV=${DEV} PYTHONUNBUFFERED=1 EXPLORI_REDIS_HOST=${REDIS_HOST} EXPLORI_REDIS_PORT=${REDIS_PORT} PYTHONPATH=src/ uvicorn server.main:app --host 0.0.0.0 --port 8080"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.22.4
 celery==5.2.7
 fastapi==0.86.0
 lxml==4.9.1

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   webserver:
     build:

--- a/docker-compose.mount-ocels.yml
+++ b/docker-compose.mount-ocels.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   celery:
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   webserver:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   webserver:
     build:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,19 +1,19 @@
-ARG BUILD_ENV
+ARG BUILD_ENV=default
 
-FROM node:18.13.0-slim@sha256:bc946484118735406562f17c57ddf5fded436e175b6a51f827aa6540ba1e13de as common_pre_build
+FROM node:18.13.0-slim@sha256:bc946484118735406562f17c57ddf5fded436e175b6a51f827aa6540ba1e13de AS common_pre_build
 ONBUILD WORKDIR /explori/webserver
 ONBUILD COPY package.json .
 ONBUILD COPY package-lock.json .
 ONBUILD RUN npm install
 
-FROM common_pre_build as prod_build
+FROM common_pre_build AS prod_build
 ONBUILD COPY public/ public/
 ONBUILD COPY src/ src/
 ONBUILD COPY tsconfig.json .
 # TODO: uncomment once frontend (e.g. api.ts `API_BASE_URL`) supports production mode using nginx reverse proxy
 #ONBUILD ENV NODE_ENV production
 
-FROM common_pre_build as dev_build
+FROM common_pre_build AS dev_build
 
 FROM ${BUILD_ENV}_build
-CMD PORT=3000 npm run start
+CMD ["env", "PORT=3000", "npm", "run", "start"]


### PR DESCRIPTION
## Overview
- Update syntax and keywords of files to make the service run on local machine seamlessly

## Change Log
- `requirements.txt`
  - Add numpy version constraints `numpy==1.22.4` for satisfying pandas and pm4py version at the same time 
- `app.sh`
  - Add lines for checking `docker compose` is the right command for docker-compose
  - Add checking for `realpath` installation
  - Set `_backend_base` as default build
  - Divide file `-f` build and up to separate lines
    - Sequentially build and up
    - `_backend_base` is excluded for file build
  -  Change `exit -1` to `exit 1` for error cases
- `Dockerfile`s
  - Resolve `FromAsCasing` error by converting `as` $\rightarrow$ `AS`
  - Resolve `InvalidDefaultArgInFrom` error by setting default value to `ARG BUILD_ENV=default`
    - With default value, the  `args` values delivered from `docker-compose.yml` would work as a parameter value
  - Resolve `JSONArgsRecommended` by changing style of `CMD` lines
    - Without variable: `CMD ["env", "PORT=3000", "npm", "run", "start"]`
    - With variable: `CMD ["sh", "-c", "DEV=${DEV} PYTHONUNBUFFERED=1..."]`

## To Reviewer
- Changing ordinary `xes` log file to object-centric log file format `jsonocel`, `xesocel` is mendatory to utilize the service
- Currently there are no ways available in python except for manually convert logs into ocel style

## Issue Tags
- Fixed:
- See also: